### PR TITLE
Removed unnecessary resolvers and updated Scala version.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -13,18 +13,13 @@ object finaglezk extends Build {
       "junit" % "junit" % "4.11" % "test",
       "org.mockito" % "mockito-all" % "1.9.5" % "test",
       "org.slf4j" % "slf4j-api" % "1.7.7"
-    ),
-    resolvers ++= Seq("snapshots" at "http://oss.sonatype.org/content/repositories/snapshots",
-      "releases" at "http://oss.sonatype.org/content/repositories/releases",
-      "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/",
-      "twitter-repo" at "http://maven.twttr.com"
     )
   )
 
   lazy val buildSettings = Seq(
     organization := "com.twitter.finagle",
     version := FinVersion,
-    crossScalaVersions := Seq("2.9.2", "2.10.0"),
+    crossScalaVersions := Seq("2.9.2", "2.10.4"),
     logLevel := Level.Debug
   )
 


### PR DESCRIPTION
All of your dependencies are in Maven Central, so you don't need the extra resolvers. I've also updated the Scala version at the same time, but that's unrelated.
