### PR TITLE
Updated Finagle and Scala versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,17 @@
 language: scala
 scala:
   - 2.10.4
+  - 2.11.4
 
 jdk:
   - oraclejdk7
+  - oraclejdk8
   - openjdk7
 
 script:
   - "sbt ++$TRAVIS_SCALA_VERSION core/test"
   - "sbt ++$TRAVIS_SCALA_VERSION runTests"
-  
+
 before_install:
   - sudo chmod +x integration/src/main/resources/scripts/runQuorumMode.sh
   - sudo chmod +x integration/src/main/resources/scripts/runStandaloneMode.sh

--- a/core/src/main/scala/com/twitter/finagle/exp/zookeeper/connection/Connection.scala
+++ b/core/src/main/scala/com/twitter/finagle/exp/zookeeper/connection/Connection.scala
@@ -1,5 +1,6 @@
 package com.twitter.finagle.exp.zookeeper.connection
 
+import com.twitter.finagle.Status
 import com.twitter.finagle.exp.zookeeper.{RepPacket, ReqPacket}
 import com.twitter.finagle.{Service, ServiceFactory}
 import com.twitter.util.{Duration, Future, Time}
@@ -65,6 +66,7 @@ class Connection(serviceFactory: ServiceFactory[ReqPacket, RepPacket]) {
     }
   }
 
+  def serviceFactoryStatus: Status = serviceFactory.status
   def isServiceFactoryAvailable: Boolean = serviceFactory.isAvailable
   def isServiceAvailable: Future[Boolean] = service flatMap
     (svc => Future(svc.isAvailable))

--- a/core/src/main/scala/com/twitter/finagle/exp/zookeeper/transport/ZkTransport.scala
+++ b/core/src/main/scala/com/twitter/finagle/exp/zookeeper/transport/ZkTransport.scala
@@ -1,5 +1,6 @@
 package com.twitter.finagle.exp.zookeeper.transport
 
+import com.twitter.finagle.Status
 import com.twitter.finagle.netty3.ChannelBufferBuf
 import com.twitter.finagle.transport.Transport
 import com.twitter.io.Buf
@@ -20,7 +21,7 @@ private[finagle] class ZkTransport(trans: Transport[ChannelBuffer, ChannelBuffer
 
   @volatile var buf = Buf.Empty
   def close(deadline: Time): Future[Unit] = trans.close(deadline)
-  def isOpen: Boolean = trans.isOpen
+  def status: Status = trans.status
   def localAddress: SocketAddress = trans.localAddress
   val maxBuffer: Int = 4096 * 1024
   val onClose: Future[Throwable] = trans.onClose
@@ -66,7 +67,7 @@ private[finagle] class BufTransport(trans: Transport[ChannelBuffer, ChannelBuffe
   extends Transport[Buf, Buf] {
 
   def close(deadline: Time): Future[Unit] = trans.close(deadline)
-  def isOpen: Boolean = trans.isOpen
+  def status: Status = trans.status
   def localAddress: SocketAddress = trans.localAddress
   val onClose: Future[Throwable] = trans.onClose
   def remoteAddress: SocketAddress = trans.remoteAddress

--- a/integration/src/test/scala/com/twitter/finagle/exp/zookeeper/integration/quorum/QuorumIntegrationConfig.scala
+++ b/integration/src/test/scala/com/twitter/finagle/exp/zookeeper/integration/quorum/QuorumIntegrationConfig.scala
@@ -30,7 +30,7 @@ trait QuorumIntegrationConfig extends FunSuite {
     client1 = {
       if (!isPortAvailable(2181))
         Some(
-          Zookeeper
+          Zookeeper.client
             .withAutoReconnect()
             .withZkConfiguration(sessionTimeout = timeOut)
             .newRichClient(ipAddress + ":" + 2181)
@@ -41,7 +41,7 @@ trait QuorumIntegrationConfig extends FunSuite {
     client2 = {
       if (!isPortAvailable(2182))
         Some(
-          Zookeeper
+          Zookeeper.client
             .withAutoReconnect()
             .withZkConfiguration(sessionTimeout = timeOut)
             .newRichClient(ipAddress + ":" + 2182)
@@ -52,7 +52,7 @@ trait QuorumIntegrationConfig extends FunSuite {
     client3 = {
       if (!isPortAvailable(2183))
         Some(
-          Zookeeper
+          Zookeeper.client
             .withAutoReconnect()
             .withZkConfiguration(sessionTimeout = timeOut)
             .newRichClient(ipAddress + ":" + 2183)

--- a/integration/src/test/scala/com/twitter/finagle/exp/zookeeper/integration/standalone/StandaloneIntegrationConfig.scala
+++ b/integration/src/test/scala/com/twitter/finagle/exp/zookeeper/integration/standalone/StandaloneIntegrationConfig.scala
@@ -27,7 +27,7 @@ trait StandaloneIntegrationConfig extends FunSuite {
     client = {
       if (!isPortAvailable)
         Some(
-          Zookeeper
+          Zookeeper.client
             .withAutoReconnect()
             .withZkConfiguration(sessionTimeout = timeOut)
             .newRichClient(ipAddress + ":" + port)

--- a/integration/src/test/scala/com/twitter/finagle/exp/zookeeper/integration/standalone/v3_4/command/ChrootTest.scala
+++ b/integration/src/test/scala/com/twitter/finagle/exp/zookeeper/integration/standalone/v3_4/command/ChrootTest.scala
@@ -15,13 +15,13 @@ import org.scalatest.junit.JUnitRunner
 class ChrootTest extends FunSuite with StandaloneIntegrationConfig {
   test("Chroot works") {
     val clientWCh = Some(
-      Zookeeper
+      Zookeeper.client
         .withAutoReconnect()
         .withZkConfiguration(chroot = "/ch1")
         .newRichClient(ipAddress + ":" + port)
     )
     val client = Some(
-      Zookeeper
+      Zookeeper.client
         .withAutoReconnect()
         .newRichClient(ipAddress + ":" + port)
     )

--- a/integration/src/test/scala/com/twitter/finagle/exp/zookeeper/integration/standalone/v3_4/command/WatcherTest.scala
+++ b/integration/src/test/scala/com/twitter/finagle/exp/zookeeper/integration/standalone/v3_4/command/WatcherTest.scala
@@ -216,7 +216,7 @@ class WatcherTest extends StandaloneIntegrationConfig {
       } yield None
     }
 
-    val client2 = Zookeeper
+    val client2 = Zookeeper.client
       .withZkConfiguration(true, true, "/ch1")
       .newRichClient(ipAddress + ":" + port)
 
@@ -265,7 +265,7 @@ class WatcherTest extends StandaloneIntegrationConfig {
       } yield None
     }
 
-    val client2 = Zookeeper
+    val client2 = Zookeeper.client
       .withZkConfiguration(true, true, "/ch1/here/we")
       .newRichClient(ipAddress + ":" + port)
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2,7 +2,7 @@ import sbt._
 import Keys._
 
 object finaglezk extends Build {
-  val finagleVersion = "6.20.0"
+  val finagleVersion = "6.24.0"
   val clientVersion = "0.2.0"
 
   lazy val root = Project(
@@ -30,11 +30,10 @@ object finaglezk extends Build {
 
   lazy val baseSettings = Seq(
     libraryDependencies ++= Seq(
-      "org.scalatest" %% "scalatest" % "2.2.0",
+      "org.scalatest" %% "scalatest" % "2.2.2",
       "com.twitter" %% "finagle-core" % finagleVersion,
-      "junit" % "junit" % "4.11",
-      "com.google.guava" % "guava" % "17.0",
-      "org.mockito" % "mockito-all" % "1.9.5" % "test"
+      "junit" % "junit" % "4.12",
+      "org.mockito" % "mockito-all" % "1.10.8" % "test"
     )
   )
 
@@ -42,7 +41,8 @@ object finaglezk extends Build {
     name := "finagle-ZooKeeper",
     organization := "com.twitter",
     version := clientVersion,
-    crossScalaVersions := Seq("2.10.4"),
+    scalaVersion := "2.10.4",
+    crossScalaVersions := Seq("2.10.4", "2.11.4"),
     scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")
   )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.7


### PR DESCRIPTION
Problem

The project was a couple of Finagle versions behind, and there have been some
changes to the Stack API in the meantime.

Solution

I've had to make some changes to the public API; in particular there's no more
`ZookeeperClient` or `ZookeeperStackClient`. I'm not sure the implementation of
`Zookeeper.newClient` is ideal, but all tests pass.

Result

Updated to Finagle 6.24.0, which also means we can cross-build for Scala 2.11.
